### PR TITLE
speed-up softmax

### DIFF
--- a/llama2.cu
+++ b/llama2.cu
@@ -248,8 +248,9 @@ __global__ void softmax_kernel(half* __restrict__ arr, int num_heads, int size) 
     sum = shared_val;
 
     // normalize and write the result
+    float inv_sum = 1.0f / sum;
     for (int t = tid; t < size; t += step)
-        arr_base[t] = (half) (att[t] / sum);
+        arr_base[t] = (half) (att[t] * inv_sum);
 }
 
 __global__ void silu_element_wise_mul_kernel(half* dest, half* src, int size) {

--- a/llama2.cu
+++ b/llama2.cu
@@ -211,9 +211,11 @@ __global__ void softmax_kernel(half* __restrict__ arr, int num_heads, int size) 
     int tid = threadIdx.x;
     int step = blockDim.x;
 
+    half* __restrict__ arr_base = arr + h * size;
+
     // load input to shared memory
     for (int t = tid; t < size; t += step)
-        att[t] = (float) arr[h * size + t];
+        att[t] = (float) arr_base[t];
     __syncthreads();
 
     using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -247,7 +249,7 @@ __global__ void softmax_kernel(half* __restrict__ arr, int num_heads, int size) 
 
     // normalize and write the result
     for (int t = tid; t < size; t += step)
-        arr[h * size + t] = (half) (att[t] / sum);
+        arr_base[t] = (half) (att[t] / sum);
 }
 
 __global__ void silu_element_wise_mul_kernel(half* dest, half* src, int size) {


### PR DESCRIPTION
This change pre-computes `arr[h * size]` into `arr_base`

But instead of using a new variable `arr_base`:

```c
half* __restrict__ arr_base = arr + h * size;
```

It could just use the value on the same `arr` variable:

```c
arr = arr + h * size;
```

or

```c
arr += h * size;
```